### PR TITLE
Fix: Eventlet import order to prevent Werkzeug request context error

### DIFF
--- a/run_web_ui.py
+++ b/run_web_ui.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+import eventlet
+eventlet.monkey_patch()  
 # Copyright (c) Meta Platforms, Inc. and affiliates
 """
 Web UI Launcher for DocAgent Docstring Generator


### PR DESCRIPTION
## Summary

This pull request addresses a `RuntimeError: Working outside of request context` that occurred due to improper import order when using `eventlet` with Flask/Werkzeug.

## Problem

The issue arose because `eventlet.monkey_patch()` was invoked *after* other modules were already imported, including those relying on standard libraries that eventlet patches (like `socket`, `thread`, etc.). This led to issues with Werkzeug expecting an active request context that wasn't properly handled in the patched environment.

## Solution

To fix this, `import eventlet` and `eventlet.monkey_patch()` have been moved to the **top** of `run_web_ui.py`, before any other imports. This ensures eventlet monkey-patches the standard library correctly and early, avoiding context-related errors during runtime.

